### PR TITLE
openapi: baize version updated to v0.26.0

### DIFF
--- a/docs/openapi/baize/v0.26.0.md
+++ b/docs/openapi/baize/v0.26.0.md
@@ -1,0 +1,1 @@
+# <swagger-ui src="v0.26.0.json">


### PR DESCRIPTION
openapi: baize version updated to v0.26.0